### PR TITLE
Fixed the Reindexing Script and added script to extract frames from video

### DIFF
--- a/Helper/video_to_image.py
+++ b/Helper/video_to_image.py
@@ -1,0 +1,65 @@
+# Import Essential Libraries
+import cv2
+import os
+
+
+# Function to extract frames from a video (every 3 seconds)
+def extract_frames(video_path, output_path, interval=3):
+    """
+    Extract frames from a video at a specified interval and save them as images.
+
+    Parameters:
+    video_path (str): Path to the input video file.
+    output_path (str): Directory where the extracted frames will be saved.
+    interval (int): Time interval (in seconds) between each frame to be extracted. Default is 3 seconds.
+
+    Returns:
+    None
+    """
+    # Read the video from specified path
+    cap = cv2.VideoCapture(video_path)
+    # Check if the video is opened successfully
+    if not cap.isOpened():
+        print("Error opening video stream or file")
+        return
+
+    # Get the frame rate of the video
+    fps = cap.get(cv2.CAP_PROP_FPS)
+    frame_interval = int(fps * interval)
+
+    # Read the video frame by frame
+    count = 0
+    frame_count = 0
+    while cap.isOpened():
+        # Capture frame-by-frame
+        ret, frame = cap.read()
+        if ret:
+            # Save the frame to the output path at the specified interval
+            if count % frame_interval == 0:
+                cv2.imwrite(os.path.join(output_path, f"frame{frame_count}.jpg"), frame)
+                frame_count += 1
+            count += 1
+        else:
+            break
+
+    # Release the VideoCapture object
+    cap.release()
+    # Close all the frames
+    cv2.destroyAllWindows()
+    print("Frames extracted successfully!")
+
+
+# Driver Code
+video_paths = [
+    "data/raw/IMG_4760.MOV",
+    "data/raw/IMG_4762.MOV",
+    "data/raw/IMG_4763.MOV",
+    "data/raw/IMG_4765.MOV",
+]
+
+output_path = "data/raw_images/"
+if not os.path.exists(output_path):
+    os.makedirs(output_path)
+
+for video_path in video_paths:
+    extract_frames(video_path, output_path)


### PR DESCRIPTION
This pull request includes significant updates to the `Helper/reindexing.py` and `Helper/video_to_image.py` files. The changes focus on enhancing the reindexing of annotations in text files and adding a new function to extract frames from videos.

**1. Enhancements to reindexing annotations:**

* Renamed the function from `update_labels` to `reindex_annotations` and added detailed docstrings and logging to improve clarity and traceability.
* Improved the logic for updating annotation files by handling cases where label names are not in the standard label map and logging the changes made to class indices.
* Updated the YAML file with new label names and ensured the correct order of labels.
* Adjusted the order of labels in the `standard_label_map` dictionary to match the new standard.

**2. New functionality for extracting frames from videos:**

* Added a new function `extract_frames` to extract frames from a video at a specified interval and save them as images. This includes reading the video, capturing frames at intervals, and saving them to a specified directory.